### PR TITLE
Fix default ABI on powerpc64

### DIFF
--- a/libffi-sys-rs/src/arch.rs
+++ b/libffi-sys-rs/src/arch.rs
@@ -242,12 +242,10 @@ mod powerpc {
         pub const ffi_abi_FFI_LINUX: ffi_abi = 0b00_1000;
 
         mod elfv1 {
-            pub const STRUCT_ALIGN_FLAG: crate::ffi_abi = 0b0;
             pub const FFI_TRAMPOLINE_SIZE: usize = 24;
         }
 
         mod elfv2 {
-            pub const STRUCT_ALIGN_FLAG: crate::ffi_abi = super::ffi_abi_FFI_LINUX_STRUCT_ALIGN;
             pub const FFI_TRAMPOLINE_SIZE: usize = 32;
         }
 
@@ -279,7 +277,6 @@ mod powerpc {
         }
 
         pub use elf::FFI_TRAMPOLINE_SIZE;
-        use elf::STRUCT_ALIGN_FLAG;
 
         mod long_double_64 {
             pub const LONG_DOUBLE_128_FLAG: crate::ffi_abi = 0b0;
@@ -300,7 +297,7 @@ mod powerpc {
         use long_double_128::*;
 
         pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi =
-            ffi_abi_FFI_LINUX | STRUCT_ALIGN_FLAG | LONG_DOUBLE_128_FLAG;
+            ffi_abi_FFI_LINUX | ffi_abi_FFI_LINUX_STRUCT_ALIGN | LONG_DOUBLE_128_FLAG;
 
         pub const FFI_NATIVE_RAW_API: u32 = 0;
         pub const FFI_GO_CLOSURES: u32 = 1;


### PR DESCRIPTION
On big-endian powerpc64, the LINUX_STRUCT_ALIGN flag was not set in the default ABI. However, [according to libffi](https://github.com/libffi/libffi/blob/v3.5.0/src/powerpc/ffitarget.h#L97) it should be. It requires `__STRUCT_PARM_ALIGN__` to be defined, but from what I can see it has no relation to big- or low-endian architectures, but may relate to [old gcc versions that did not properly align structs](https://gcc.gnu.org/legacy-ml/gcc-patches/2013-09/msg00890.html), although this is sort of speculation on my part.

This PR sets the `LINUX_STRUCT_ALIGN` flag unconditionally for the default powerpc64 ABI. I set `master` as the target for this PR, but let me know if you want to merge this to `next` instead.

I discovered this yesterday when making a [test with the new `ffi_get_default_abi` function](https://github.com/emiltayl/libffi-rs/commit/34992638fbd8700ecea6551f13048a7f7277f21b). I can upstream that test as well, but that requires upgrading to libffi 3.5.0 first.