### PR TITLE
also add lib32 dir to search path (needed for multilib)

### DIFF
--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -6,6 +6,7 @@ pub fn build_and_link() {
     let build_dir = Path::new(&out_dir).join("libffi-build");
     let prefix = Path::new(&out_dir).join("libffi-root");
     let libdir = Path::new(&prefix).join("lib");
+    let libdir32 = Path::new(&prefix).join("lib32");
     let libdir64 = Path::new(&prefix).join("lib64");
 
     // Copy LIBFFI_DIR into build_dir to avoid an unnecessary build
@@ -53,6 +54,7 @@ pub fn build_and_link() {
     // Cargo linking directives
     println!("cargo:rustc-link-lib=static=ffi");
     println!("cargo:rustc-link-search={}", libdir.display());
+    println!("cargo:rustc-link-search={}", libdir32.display());
     println!("cargo:rustc-link-search={}", libdir64.display());
 }
 


### PR DESCRIPTION
When installing 32bit rustc on a 64bit system using a "multilib" setup (`sudo apt install gcc-multilib`), building libffi fails. The reason is that the build ends up being stored in a folder called `lib32`, but the build script only adds `lib` and `lib64` to the search path. So let's also add `lib32` to fix that.
Fixes https://github.com/libffi-rs/libffi-rs/issues/159