### PR TITLE
add check_only feature to disable building the C code

### DIFF
--- a/libffi-rs/Cargo.toml
+++ b/libffi-rs/Cargo.toml
@@ -18,6 +18,8 @@ libc = "0.2.65"
 [features]
 complex = []
 system = ["libffi-sys/system"]
+# Can be used to accelerate check builds by not building C code
+check_only = ["libffi-sys/check_only"]
 
 [package.metadata.docs.rs]
 features = ["system"]

--- a/libffi-sys-rs/Cargo.toml
+++ b/libffi-sys-rs/Cargo.toml
@@ -15,6 +15,8 @@ rust-version.workspace = true
 [features]
 system = []
 complex = []
+# Can be used to accelerate check builds by not building C code
+check_only = []
 
 [package.metadata.docs.rs]
 features = ["system"]

--- a/libffi-sys-rs/build/build.rs
+++ b/libffi-sys-rs/build/build.rs
@@ -10,6 +10,9 @@ use msvc::*;
 use not_msvc::*;
 
 fn main() {
+    if cfg!(feature = "check_only") {
+        return;
+    }
     if cfg!(feature = "system") {
         probe_and_link();
     } else {


### PR DESCRIPTION
I am looking into ways for how we can speed up check-builds in Miri (see https://github.com/rust-lang/miri/issues/4461). The libffi build script accounts for a significant fraction of the remaining build time here since the C code still gets built, even when that is entirely unnecessary for a check build.

In the rustc workspace, we have a `check_only` feature on some crates for exactly this purpose. I wonder if you'd be open to the idea of having a similar feature for libffi? Of course I would prefer to actually have native support in cargo for this but that idea has a bunch of unanswered design questions (https://github.com/rust-lang/cargo/issues/4001). So meanwhile, the best we can do is hack it in ourselves. This is done with a cargo feature to have cargo properly cache the build with and without the feature and avoid rebuilds when the flag changes. I'm happy to bikeshed the name, e.g. making it more clear that this is an unstable/unsupported configuration if you prefer that.  Could you imagine landing something like this?