### PR TITLE
Fix leak of ffi_closure on panic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,6 @@ jobs:
         features:
           - "--no-default-features"
           - "--features std"
-          - "--features std,system"
     runs-on: windows-latest
     name: windows-gnu ${{ matrix.toolchain }} ${{ matrix.features }}
     steps:


### PR DESCRIPTION
Wraps ffi_closure in its own struct to prevent a panic from prep_closure_mut from causing a leak of a ffi_closure object.

Fixes: #149 