### PR TITLE
Fix cross-compile for riscv64a23 target

### DIFF
--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -81,6 +81,7 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
             // Autoconf uses riscv64 while Rust uses riscv64gc for the architecture
             "riscv64gc-unknown-linux-gnu" => "riscv64-unknown-linux-gnu",
             "riscv64gc-unknown-linux-musl" => "riscv64-unknown-linux-musl",
+            "riscv64a23-unknown-linux-gnu" => "riscv64-unknown-linux-gnu",
             // Autoconf does not yet recognize illumos, but Solaris should be fine
             "x86_64-unknown-illumos" => "x86_64-unknown-solaris",
             // configure.host does not extract `ios-sim` as OS.


### PR DESCRIPTION
Fix cross-compile for riscv64a23-unknown-linux-gnu ( Tier-3 target in Rust)