### PR TITLE
Add tests for default ABI and ffi_closure size

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: Run tests
-        run: cargo test ${{ matrix.features }}
+        run: cargo test --workspace ${{ matrix.features }}
 
   windows-gnu:
     strategy:
@@ -65,7 +65,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - name: Run tests
         shell: msys2 {0}
-        run: cargo test ${{ matrix.features }}
+        run: cargo test --workspace ${{ matrix.features }}
 
   macos:
     strategy:
@@ -91,7 +91,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: Run tests
-        run: 'cargo test ${{ matrix.features }}'
+        run: 'cargo test --workspace ${{ matrix.features }}'
 
   linux:
     strategy:
@@ -115,7 +115,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: Run tests
-        run: 'cargo test ${{ matrix.features }}'
+        run: 'cargo test --workspace ${{ matrix.features }}'
 
   free-bsd:
     runs-on: ubuntu-latest
@@ -132,7 +132,7 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           run: |
             . "$HOME/.cargo/env"
-            cargo test
+            cargo test --workspace 
 
   qemu:
     runs-on: ubuntu-latest

--- a/libffi-sys-rs/src/arch.rs
+++ b/libffi-sys-rs/src/arch.rs
@@ -436,3 +436,24 @@ pub use mips::mips::*;
 
 #[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
 pub use mips::mips64::*;
+
+#[cfg(all(test, feature = "std"))]
+mod test {
+    use core::ffi::c_uint;
+
+    use super::*;
+
+    // `ffi_get_default_abi` was added in libffi v3.5.0. This test cannot be
+    // executed without the function, so it is disabled when performing dynamic
+    // linking to libffi until version 3.5.0. is required for dynamic linking by
+    // libffi-rs.
+    #[cfg(not(feature = "system"))]
+    #[test]
+    fn verify_default_abi() {
+        extern "C" {
+            fn ffi_get_default_abi() -> c_uint;
+        }
+
+        unsafe { assert_eq!(ffi_abi_FFI_DEFAULT_ABI, ffi_get_default_abi()) }
+    }
+}

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -748,4 +748,23 @@ mod test {
             assert_eq!(rval, 9);
         }
     }
+
+    // Verify that `ffi_closure` is the correct size. This does not guarantee
+    // that the layout of the struct is correct, but it *should* not matter much
+    // as `ffi_closure` *should* not be modified outside of libffi.
+    // `ffi_get_closure_size` was added in libffi v3.5.0. This test cannot be
+    // executed without the function, so it is disabled when performing dynamic
+    // linking to libffi until version 3.5.0. is required for dynamic linking by
+    // libffi-rs.
+    #[cfg(not(feature = "system"))]
+    #[test]
+    fn verify_ffi_closure_size() {
+        extern "C" {
+            fn ffi_get_closure_size() -> usize;
+        }
+
+        unsafe {
+            assert_eq!(std::mem::size_of::<ffi_closure>(), ffi_get_closure_size());
+        }
+    }
 }


### PR DESCRIPTION
Libffi v3.5.0 added the functions `ffi_get_default_abi` and `ffi_get_closure_size` that returns the default ABI and the size of `ffi_closure` respectively. This PR adds tests that uses these functions to ensure that there is no mismatch between the Rust crate and the actual libffi library.

Note that I also modified the `test.yml` GitHub action and added `--workspace` to the `cargo test` commands to ensure that libffi-sys tests were also executed by the action.